### PR TITLE
add [] to get-price-levels marketMakers param

### DIFF
--- a/hashflow/api.py
+++ b/hashflow/api.py
@@ -53,7 +53,7 @@ class HashflowApi:
         params = {
             "source": self.source,
             "networkId": chain_id,
-            "marketMakers": market_makers,
+            "marketMakers[]": market_makers,
         }
         if self.wallet is not None:
             params["wallet"] = self.wallet

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,7 +58,7 @@ class TestWallet:
                     params={
                         "source": "api",
                         "networkId": TEST_CHAIN_ID,
-                        "marketMakers": TEST_MARKET_MAKERS_LIST,
+                        "marketMakers[]": TEST_MARKET_MAKERS_LIST,
                         "wallet": TEST_WALLET_ADDRESS,
                     },
                 )
@@ -138,7 +138,7 @@ class TestTaker:
                     params={
                         "source": "test_taker_client",
                         "networkId": TEST_CHAIN_ID,
-                        "marketMakers": TEST_MARKET_MAKERS_LIST,
+                        "marketMakers[]": TEST_MARKET_MAKERS_LIST,
                     },
                 )
             ]


### PR DESCRIPTION
Unlike javascript, python does not add [] to the parameter name when the parameter value is an array. So we add it manually.